### PR TITLE
Enhance AI features and update CI workflows and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+@AGENTS.md
+
+# Claude Policy Fallback
+
+This file is a concise fallback summary for AI agents. If anything here conflicts with [AGENTS.md](AGENTS.md), the AGENTS policy wins.
+
+## Core Rules
+
+- Do not read, expose, copy, summarize, or log secrets or personal data.
+- Never hardcode API keys, tokens, passwords, connection strings, webhook URLs, or private emails.
+- Read secrets from environment variables or approved secret stores only.
+- Do not place secrets in frontend code, static assets, documentation, tests, or commit messages.
+- Keep logs and error messages sanitized; do not expose tokens, cookies, request bodies, or raw provider errors.
+- Validate and sanitize untrusted input before use.
+- Do not weaken auth or permission boundaries.
+- Prefer secure defaults and ask for clarification before handling sensitive data.
+- Avoid unnecessary dependencies and untrusted external calls.
+- After every major change, run build and lint checks, or the closest available project checks, and fix relevant failures before finalizing.
+
+## Checklist Before Finalizing
+
+- No hardcoded secret-like values were introduced.
+- No sensitive values are logged or returned in API responses.
+- All keys and secrets come from environment variables or approved secret stores.
+- Frontend or client bundles do not contain backend secrets.
+- New docs and config examples use placeholders only.


### PR DESCRIPTION
This pull request introduces a new fallback policy document for AI agent security practices. The new `CLAUDE.md` file provides a concise summary of core security rules and a checklist to ensure sensitive data is handled appropriately, serving as a backup to the more comprehensive `AGENTS.md` policy.

Security policy documentation:

* Added `CLAUDE.md` as a fallback summary of security rules for AI agents, emphasizing the protection of secrets, proper handling of sensitive data, and secure coding practices. The document includes both core rules and a pre-finalization checklist, and clarifies that `AGENTS.md` takes precedence in case of conflicts.