### PR TITLE
fix: change npm ci to npm i for installing dependencies in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Install backend dependencies
         working-directory: be
-        run: npm ci
+        run: npm i
 
       - name: Install frontend dependencies
         working-directory: fe
-        run: npm ci
+        run: npm i
 
       - name: Lint frontend
         working-directory: fe


### PR DESCRIPTION
This pull request updates the CI workflow to use a different command for installing dependencies in both the backend and frontend. Instead of using `npm ci`, the workflow now uses `npm i` for dependency installation.

- CI workflow update:
  * Changed the dependency installation command from `npm ci` to `npm i` for both backend (`be`) and frontend (`fe`) in the `.github/workflows/ci.yml` file.